### PR TITLE
Display sets via SessionExerciseListItem

### DIFF
--- a/src/components/session/SessionExerciseListItem.tsx
+++ b/src/components/session/SessionExerciseListItem.tsx
@@ -1,22 +1,15 @@
-// src/components/sessions/SessionExerciseListItem.tsx (New File)
 import React from 'react';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Timer } from 'lucide-react';
-import { SessionSetListItem } from './SessionSetListItem'; // Import the set item component
-import { PlanSessionExercise } from '@/types/planTypes';
-import { Button } from '../ui/button';
-
-// Adjust the type to match the structure within your session data
-interface SessionExercise extends Omit<PlanSessionExercise, 'plan_session_exercise_sets' | 'exercise'> {
-    exercises: PlanSessionExercise['exercise']; // Nested exercise details
-    plan_session_exercise_sets: PlanSessionExercise['plan_session_exercise_sets']; // Array of sets for the session
-    target_rest_seconds?: number | null; // Rest AFTER this exercise block
-    // Add any other fields specific to the session exercise if needed
-}
-
+import { SessionSetListItem } from './SessionSetListItem';
+import type { PlanSessionExercise } from '@/types/planTypes';
+import { cn } from '@/lib/utils';
 
 interface SessionExerciseListItemProps {
-    sessionExercise: SessionExercise; // Pass the exercise object from the session data
+    sessionExercise: PlanSessionExercise;
+    imageUrl?: string;
+    className?: string;
+    onClick?: () => void;
 }
 
 // Helper to format rest time nicely (can be shared)
@@ -29,17 +22,21 @@ const formatRest = (seconds: number | null | undefined) => {
 };
 
 
-export function SessionExerciseListItem({ sessionExercise }: SessionExerciseListItemProps) {
-    const exerciseDetails = sessionExercise.exercises; // Access nested details
+export function SessionExerciseListItem({ sessionExercise, imageUrl, className, onClick }: SessionExerciseListItemProps) {
+    const exerciseDetails = sessionExercise.exercise;
     const sets = sessionExercise.plan_session_exercise_sets || []; // Ensure sets is an array
     const restAfterExercise = formatRest(sessionExercise.target_rest_seconds);
 
     return (
-        <Card className="overflow-hidden">
+        <Card className={cn("overflow-hidden", className)} onClick={onClick}>
             <CardHeader className="flex flex-row items-start gap-4 p-4 bg-muted/30">
                 {/* Image */}
-                 <div className="flex-shrink-0 w-20 h-20 rounded-md overflow-hidden bg-muted">
-                   
+                <div className="flex-shrink-0 w-20 h-20 rounded-md overflow-hidden bg-muted">
+                    <img
+                        src={imageUrl || '/placeholder.svg'}
+                        className="object-cover w-full h-full"
+                        onError={(e) => (e.currentTarget.src = '/placeholder.svg')}
+                    />
                 </div>
                  {/* Title and Notes */}
                 <div className="flex-grow">

--- a/src/routes/_layout/$sessionId/index.tsx
+++ b/src/routes/_layout/$sessionId/index.tsx
@@ -6,7 +6,6 @@ import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
 import { AlertCircle, ArrowLeft } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader } from '@/components/ui/card';
-import { SessionExerciseListItem } from '@/components/session/SessionExerciseListItem';
 import { useLogWorkout } from '@/api/workouts';
 import { WorkoutLogger } from '@/components/session/WorkoutLogger';
 // Import your new display components

--- a/src/routes/_layout/plans/$planId/_layout/$weekId/_layout/$dayId/_layout/$sessionId/index.tsx
+++ b/src/routes/_layout/plans/$planId/_layout/$weekId/_layout/$dayId/_layout/$sessionId/index.tsx
@@ -1,8 +1,7 @@
 import { usePlanDetails } from '@/api/plans/plan';
-import { PlanSessionExerciseItem } from '@/components/PlanSessionExercise';
 import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from '@/components/ui/accordion';
 import { Button } from '@/components/ui/button';
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Card, CardHeader, CardTitle } from '@/components/ui/card';
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger } from '@/components/ui/dialog';
 import { createFileRoute } from '@tanstack/react-router'
 import { Clock, Plus, PlusCircle, Trash2, Repeat, Weight, Timer, Route as RouteIcon } from 'lucide-react';
@@ -28,67 +27,25 @@ import { Badge } from '@/components/ui/badge';
 import { useTeamStore } from '@/store/useTeamStore';
 import { useActiveMemberInTeam, useMemberInTeam } from '@/api/teams';
 import { useAuthStore } from '@/hooks/useAuthStore';
-import { kgToLbs } from '@/lib/unitConversion';
 import { AspectRatio } from '@/components/ui/aspect-ratio';
+import { SessionExerciseListItem } from '@/components/session/SessionExerciseListItem';
 
 interface SessionExerciseCardProps {
   exercise: PlanSessionExercise;
   isSelected: boolean;
   onClick: () => void;
-  unit: 'imperial' | 'metric';
 }
 
-function SessionExerciseCard({ exercise, isSelected, onClick, unit }: SessionExerciseCardProps) {
+function SessionExerciseCard({ exercise, isSelected, onClick }: SessionExerciseCardProps) {
   const exImg = useExerciseImageUrl(exercise.exercise?.image_url || '');
 
   return (
-    <Card onClick={onClick} className={cn('cursor-pointer', isSelected && 'border-blue-200')}>
-      <CardHeader>
-        <CardTitle>{exercise.exercise?.name}</CardTitle>
-        <CardDescription>{exercise.notes}</CardDescription>
-      </CardHeader>
-      <CardContent>
-        <div className="flex flex-row flex-nowrap items-start gap-2 w-full">
-          <AspectRatio ratio={16 / 9} className="bg-muted rounded-md overflow-hidden flex-shrink-0 w-32">
-            <img
-              src={exImg.data || '/placeholder.svg'}
-              className="object-cover w-full h-full"
-              onError={(e) => (e.currentTarget.src = '/placeholder.svg')}
-            />
-          </AspectRatio>
-          <div className="flex flex-col gap-2 flex-1 min-w-0">
-            {exercise?.plan_session_exercise_sets?.map((set) => (
-              <div key={set.id} className="flex items-center gap-4 text-sm">
-                <Badge variant="outline">{set.set_number}</Badge>
-                {set.target_duration_seconds && (
-                  <div className="flex items-center gap-1">
-                    <Clock className="h-4 w-4 text-muted-foreground" />
-                  </div>
-                )}
-                {set.target_reps && (
-                  <div className="flex items-center gap-1">
-                    <span className="font-medium">{set.target_reps} reps</span>
-                  </div>
-                )}
-                {set.target_weight && (
-                  <div className="flex items-center gap-1">
-                    <span className="font-medium">
-                      {unit === 'imperial' ? kgToLbs(set.target_weight) : set.target_weight}{' '}
-                      {unit === 'imperial' ? 'lb' : 'kg'}
-                    </span>
-                  </div>
-                )}
-                {set.target_distance_meters && (
-                  <div className="flex items-center gap-1">
-                    <span className="font-medium">{set.target_distance_meters}m</span>
-                  </div>
-                )}
-              </div>
-            ))}
-          </div>
-        </div>
-      </CardContent>
-    </Card>
+    <SessionExerciseListItem
+      sessionExercise={exercise}
+      imageUrl={exImg.data || '/placeholder.svg'}
+      className={cn('cursor-pointer', isSelected && 'border-blue-200')}
+      onClick={onClick}
+    />
   );
 }
 
@@ -161,7 +118,6 @@ function RouteComponent() {
               setEditSession(true);
               setSelectedEx(exercise.id);
             }}
-            unit={unit}
           />
         ))}
         {thisUser?.role === 'coach' &&


### PR DESCRIPTION
## Summary
- use `SessionExerciseListItem` in session page
- add flexible props to `SessionExerciseListItem`
- drop unused imports

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*